### PR TITLE
migrate:freshの説明を修正しました

### DIFF
--- a/translation-ja/migrations.md
+++ b/translation-ja/migrations.md
@@ -128,7 +128,7 @@ Laravelの`Schema`[ファサード](/docs/{{version}}/facades)は、テーブル
 
 #### 全テーブル削除後のマイグレーション
 
-`migrate:fresh`コマンドは、データベースから全テーブルをドロップします。次に、`migrate`コマンドを実行してください。
+`migrate:fresh`コマンドは、データベースから全テーブルをドロップし、それから`migrate`コマンドを実行します。
 
     php artisan migrate:fresh
 


### PR DESCRIPTION
`migrate:fresh`の動作予想と説明が一致しなかったため、英文のドキュメントを見て確認したところ、変更箇所の訳になったため修正しました。